### PR TITLE
The `serial` wrapper searches `$PATH` too

### DIFF
--- a/src/serial_wrapper.c
+++ b/src/serial_wrapper.c
@@ -54,7 +54,7 @@ int main(int argc, char **argv) {
   pid_t child_pid = fork();
 
   if(child_pid == 0) { // Child process runs serial executable
-    int err = execv(argv[1], new_argv);
+    int err = execvp(argv[1], new_argv);
     if(err)
       EXIT_PRINT("Failed to launch executable: %s!\n", strerror(errno));
   }


### PR DESCRIPTION
Currently using the `serial` wrapper with `wraprun` requires the full path of the executable to be set. This can lead to confusing problems when a seemingly correct script doesn't work. A proposed fix is to use `execvp` to search for executables in `$PATH` too.